### PR TITLE
Create Vite React Flow task app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# react-flow
+# Task Flow
+
+Exemplo de aplicativo de fluxo de tarefas utilizando React Flow e Vite.
+
+## Scripts
+
+- `npm install` para instalar as dependências.
+- `npm run dev` para iniciar o servidor de desenvolvimento.
+- `npm run build` para gerar a versão de produção.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Task Flow</title>
+    <script type="module" src="/src/main.tsx"></script>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "task-flow",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-flow-renderer": "^11.7.5",
+    "zustand": "^4.4.7"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.12",
+    "@types/react-dom": "^18.2.4",
+    "@vitejs/plugin-react": "^4.1.0",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.5",
+    "tailwindcss": "^3.3.3",
+    "autoprefixer": "^10.4.12",
+    "postcss": "^8.4.26"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,11 @@
+import TaskFlow from './components/TaskFlow';
+
+function App() {
+  return (
+    <div className="w-screen h-screen">
+      <TaskFlow />
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/AddTaskModal.tsx
+++ b/src/components/AddTaskModal.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+interface AddTaskModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onAdd: (title: string, description: string) => void;
+}
+
+export default function AddTaskModal({ isOpen, onClose, onAdd }: AddTaskModalProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <div className="bg-white p-4 rounded w-80">
+        <h2 className="text-lg font-bold mb-2">Adicionar Tarefa</h2>
+        <input
+          className="border p-2 w-full mb-2"
+          placeholder="Título"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <textarea
+          className="border p-2 w-full mb-2"
+          placeholder="Descrição"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <div className="flex justify-end gap-2">
+          <button className="px-3 py-1" onClick={onClose}>Cancelar</button>
+          <button
+            className="bg-blue-500 text-white px-3 py-1 rounded"
+            onClick={() => {
+              onAdd(title, description);
+              setTitle('');
+              setDescription('');
+              onClose();
+            }}
+          >
+            Adicionar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TaskFlow.tsx
+++ b/src/components/TaskFlow.tsx
@@ -1,0 +1,69 @@
+import { useCallback, useState } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  addEdge,
+  Connection,
+  Edge,
+  Node,
+  useEdgesState,
+  useNodesState,
+} from 'react-flow-renderer';
+import AddTaskModal from './AddTaskModal';
+import TaskNode from './TaskNode';
+import { useFlowStore } from '../store';
+
+let id = 0;
+const getId = () => `task_${id++}`;
+
+export default function TaskFlow() {
+  const { nodes, edges, addNode, setEdges } = useFlowStore();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [nodesState, setNodesState, onNodesChange] = useNodesState(nodes);
+  const [edgesState, setEdgesState, onEdgesChange] = useEdgesState(edges);
+
+  const onConnect = useCallback(
+    (connection: Edge | Connection) =>
+      setEdgesState((eds) => addEdge(connection, eds)),
+    [setEdgesState]
+  );
+
+  const handleAdd = (title: string, description: string) => {
+    const newNode: Node = {
+      id: getId(),
+      type: 'task',
+      data: { label: title, description },
+      position: { x: Math.random() * 250, y: Math.random() * 250 },
+    };
+    addNode(newNode);
+    setNodesState((nds) => nds.concat(newNode));
+  };
+
+  return (
+    <>
+      <ReactFlow
+        nodeTypes={{ task: TaskNode }}
+        nodes={nodesState}
+        edges={edgesState}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        fitView
+      >
+        <Background />
+        <Controls />
+      </ReactFlow>
+      <button
+        className="fixed bottom-4 right-4 bg-blue-600 text-white px-4 py-2 rounded"
+        onClick={() => setModalOpen(true)}
+      >
+        Adicionar Tarefa
+      </button>
+      <AddTaskModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onAdd={handleAdd}
+      />
+    </>
+  );
+}

--- a/src/components/TaskNode.tsx
+++ b/src/components/TaskNode.tsx
@@ -1,0 +1,12 @@
+import { Handle, NodeProps, Position } from 'react-flow-renderer';
+
+export default function TaskNode({ data }: NodeProps) {
+  return (
+    <div className="bg-white p-2 rounded shadow-md border w-48">
+      <h3 className="font-bold text-sm">{data.label}</h3>
+      {data.description && <p className="text-xs mt-1">{data.description}</p>}
+      <Handle type="target" position={Position.Top} />
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+import { Edge, Node } from 'react-flow-renderer';
+
+interface FlowState {
+  nodes: Node[];
+  edges: Edge[];
+  addNode: (node: Node) => void;
+  setEdges: (edges: Edge[]) => void;
+}
+
+export const useFlowStore = create<FlowState>((set) => ({
+  nodes: [],
+  edges: [],
+  addNode: (node) => set((state) => ({ nodes: [...state.nodes, node] })),
+  setEdges: (edges) => set({ edges }),
+}));

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize vite react-ts project structure
- setup TailwindCSS
- implement basic TaskFlow with React Flow
- provide TaskNode component
- provide AddTaskModal component
- add Zustand store
- document how to run the project

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6854703b79e8832e91d231468abf6aa8