### PR TITLE
Add flow templates and loader menu

### DIFF
--- a/src/components/ApiFlow.tsx
+++ b/src/components/ApiFlow.tsx
@@ -16,6 +16,7 @@ import ConditionNode from './nodes/ConditionNode';
 import MergeNode from './nodes/MergeNode';
 import OutputNode from './nodes/OutputNode';
 import Sidebar from './Sidebar';
+import flowTemplates, { FlowTemplate } from '../examples/flowTemplates';
 import { useExecutionStore } from '../store';
 
 let id = 0;
@@ -63,6 +64,11 @@ export default function ApiFlow() {
     } catch {}
   };
 
+  const loadTemplate = (template: FlowTemplate) => {
+    setNodes(template.nodes);
+    setEdges(template.edges);
+  };
+
   const executeFlow = async () => {
     resetResults();
     const { setResult, results } = useExecutionStore.getState();
@@ -100,7 +106,11 @@ export default function ApiFlow() {
               headers,
               body: data.body && data.method !== 'GET' ? data.body : undefined,
             });
-            output = await res.json();
+            let body: any = undefined;
+            try {
+              body = await res.json();
+            } catch {}
+            output = { status: res.status, data: body };
           } catch (e) {
             output = { error: String(e) };
           }
@@ -155,7 +165,14 @@ export default function ApiFlow() {
 
   return (
     <div className="w-screen h-screen flex">
-      <Sidebar onAdd={addNode} onRun={executeFlow} onSave={saveFlow} onLoad={loadFlow} />
+      <Sidebar
+        onAdd={addNode}
+        onRun={executeFlow}
+        onSave={saveFlow}
+        onLoad={loadFlow}
+        templates={flowTemplates}
+        onLoadTemplate={loadTemplate}
+      />
       <div className="flex-1 h-full">
         <ReactFlow
           nodeTypes={nodeTypes}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,13 +1,29 @@
+import { useState } from 'react';
+import { FlowTemplate } from '../examples/flowTemplates';
+
 interface SidebarProps {
   onAdd: (type: string) => void;
   onRun: () => void;
   onSave: () => void;
   onLoad: () => void;
+  templates: FlowTemplate[];
+  onLoadTemplate: (template: FlowTemplate) => void;
 }
 
-export default function Sidebar({ onAdd, onRun, onSave, onLoad }: SidebarProps) {
+export default function Sidebar({
+  onAdd,
+  onRun,
+  onSave,
+  onLoad,
+  templates,
+  onLoadTemplate,
+}: SidebarProps) {
+  const [selected, setSelected] = useState(templates[0]?.id || '');
+
+  const current = templates.find((t) => t.id === selected);
+
   return (
-    <div className="w-48 p-2 bg-gray-200 space-y-2 text-sm">
+    <div className="w-48 p-2 bg-gray-200 space-y-2 text-sm overflow-y-auto">
       <button className="w-full bg-blue-500 text-white px-2 py-1" onClick={() => onAdd('apiRequest')}>
         Add API Request
       </button>
@@ -22,6 +38,24 @@ export default function Sidebar({ onAdd, onRun, onSave, onLoad }: SidebarProps) 
       </button>
       <button className="w-full bg-blue-500 text-white px-2 py-1" onClick={() => onAdd('output')}>
         Add Output
+      </button>
+      <hr />
+      <select
+        className="w-full border px-1 py-1"
+        value={selected}
+        onChange={(e) => setSelected(e.target.value)}
+      >
+        {templates.map((t) => (
+          <option key={t.id} value={t.id}>
+            {t.name}
+          </option>
+        ))}
+      </select>
+      <button
+        className="w-full bg-purple-600 text-white px-2 py-1"
+        onClick={() => current && onLoadTemplate(current)}
+      >
+        Carregar exemplo
       </button>
       <hr />
       <button className="w-full bg-green-600 text-white px-2 py-1" onClick={onRun}>

--- a/src/examples/flowTemplates.ts
+++ b/src/examples/flowTemplates.ts
@@ -1,0 +1,153 @@
+import { Node, Edge } from '@xyflow/react';
+
+export interface FlowTemplate {
+  id: string;
+  name: string;
+  description: string;
+  nodes: Node[];
+  edges: Edge[];
+}
+
+export const flowTemplates: FlowTemplate[] = [
+  {
+    id: 'fetch-users',
+    name: 'Buscar usuários',
+    description: 'Faz uma requisição GET e exibe o resultado',
+    nodes: [
+      {
+        id: 'req1',
+        type: 'apiRequest',
+        position: { x: 0, y: 0 },
+        data: {
+          method: 'GET',
+          url: 'https://jsonplaceholder.typicode.com/users',
+        },
+      },
+      { id: 'out1', type: 'output', position: { x: 250, y: 0 }, data: {} },
+    ],
+    edges: [{ id: 'e1-2', source: 'req1', target: 'out1' }],
+  },
+  {
+    id: 'transform-users',
+    name: 'Transformar usuários',
+    description: 'Busca usuários e extrai apenas id, name e email',
+    nodes: [
+      {
+        id: 'req1',
+        type: 'apiRequest',
+        position: { x: 0, y: 0 },
+        data: {
+          method: 'GET',
+          url: 'https://jsonplaceholder.typicode.com/users',
+        },
+      },
+      {
+        id: 'trans1',
+        type: 'transform',
+        position: { x: 250, y: 0 },
+        data: {
+          code: 'return data.map(u => ({ id: u.id, name: u.name, email: u.email }));',
+        },
+      },
+      { id: 'out1', type: 'output', position: { x: 500, y: 0 }, data: {} },
+    ],
+    edges: [
+      { id: 'e1-2', source: 'req1', target: 'trans1' },
+      { id: 'e2-3', source: 'trans1', target: 'out1' },
+    ],
+  },
+  {
+    id: 'check-status',
+    name: 'Condição de status',
+    description: 'Chama uma API e verifica se status === 200',
+    nodes: [
+      {
+        id: 'req1',
+        type: 'apiRequest',
+        position: { x: 0, y: 0 },
+        data: {
+          method: 'GET',
+          url: 'https://jsonplaceholder.typicode.com/posts/1',
+        },
+      },
+      {
+        id: 'cond1',
+        type: 'condition',
+        position: { x: 250, y: 0 },
+        data: {
+          expression: 'data.status === 200',
+        },
+      },
+      { id: 'ok', type: 'output', position: { x: 500, y: -50 }, data: {} },
+      { id: 'err', type: 'output', position: { x: 500, y: 50 }, data: {} },
+    ],
+    edges: [
+      { id: 'e1-2', source: 'req1', target: 'cond1' },
+      { id: 'e2-3', source: 'cond1', target: 'ok', sourceHandle: 'true' },
+      { id: 'e2-4', source: 'cond1', target: 'err', sourceHandle: 'false' },
+    ],
+  },
+  {
+    id: 'merge-apis',
+    name: 'Merge de duas APIs',
+    description: 'Combina usuários e posts em um único objeto',
+    nodes: [
+      {
+        id: 'users',
+        type: 'apiRequest',
+        position: { x: 0, y: -50 },
+        data: {
+          method: 'GET',
+          url: 'https://jsonplaceholder.typicode.com/users',
+        },
+      },
+      {
+        id: 'posts',
+        type: 'apiRequest',
+        position: { x: 0, y: 50 },
+        data: {
+          method: 'GET',
+          url: 'https://jsonplaceholder.typicode.com/posts',
+        },
+      },
+      { id: 'merge1', type: 'merge', position: { x: 250, y: 0 }, data: {} },
+      { id: 'out1', type: 'output', position: { x: 500, y: 0 }, data: {} },
+    ],
+    edges: [
+      { id: 'e1-m', source: 'users', target: 'merge1' },
+      { id: 'e2-m', source: 'posts', target: 'merge1' },
+      { id: 'm-out', source: 'merge1', target: 'out1' },
+    ],
+  },
+  {
+    id: 'invalid-flow',
+    name: 'Fluxo inválido',
+    description: 'Contém um erro de transformação para testes',
+    nodes: [
+      {
+        id: 'req1',
+        type: 'apiRequest',
+        position: { x: 0, y: 0 },
+        data: {
+          method: 'GET',
+          url: 'https://jsonplaceholder.typicode.com/users',
+        },
+      },
+      {
+        id: 'trans1',
+        type: 'transform',
+        position: { x: 250, y: 0 },
+        data: {
+          code: 'return data.map(u => u.id',
+        },
+      },
+      { id: 'out1', type: 'output', position: { x: 500, y: 0 }, data: {} },
+    ],
+    edges: [
+      { id: 'e1-2', source: 'req1', target: 'trans1' },
+      { id: 'e2-3', source: 'trans1', target: 'out1' },
+    ],
+  },
+];
+
+export default flowTemplates;


### PR DESCRIPTION
## Summary
- include a list of sample flow templates with HTTP requests
- output API responses with `status` and `data`
- add template loader menu in sidebar

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6854820f9f00832eaac866436059b245