### PR TITLE
Fix flow output

### DIFF
--- a/src/components/ApiFlow.tsx
+++ b/src/components/ApiFlow.tsx
@@ -78,17 +78,19 @@ export default function ApiFlow() {
   const executeFlow = async () => {
     console.log('Executing flow...');
     resetResults();
-    const { setResult, results } = useExecutionStore.getState();
+    const { setResult } = useExecutionStore.getState();
+
+    const getResults = () => useExecutionStore.getState().results;
 
     const incoming = (id: string) => edges.filter((e) => e.target === id);
     const outgoing = (id: string) => edges.filter((e) => e.source === id);
 
     const getInput = (id: string) => {
       const first = incoming(id)[0];
-      return first ? results[first.source] : undefined;
+      return first ? getResults()[first.source] : undefined;
     };
 
-    const getInputs = (id: string) => incoming(id).map((e) => results[e.source]);
+    const getInputs = (id: string) => incoming(id).map((e) => getResults()[e.source]);
 
     const canRun = (id: string, executed: Set<string>) =>
       incoming(id).every((e) => executed.has(e.source));

--- a/src/examples/flowTemplates.ts
+++ b/src/examples/flowTemplates.ts
@@ -46,7 +46,7 @@ export const flowTemplates: FlowTemplate[] = [
         type: 'transform',
         position: { x: 250, y: 0 },
         data: {
-          code: 'return data.map(u => ({ id: u.id, name: u.name, email: u.email }));',
+          code: 'return data.data.map(u => ({ id: u.id, name: u.name, email: u.email }));',
         },
       },
       { id: 'out1', type: 'output', position: { x: 500, y: 0 }, data: {} },


### PR DESCRIPTION
## Summary
- do not hold stale results in memory when executing nodes
- fix transform example to access API response correctly

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68548bb915cc832e8e522222391acb4d