### PR TITLE
Improve OutputNode display and layout

### DIFF
--- a/src/components/nodes/OutputNode.tsx
+++ b/src/components/nodes/OutputNode.tsx
@@ -3,10 +3,13 @@ import { useExecutionStore } from '../../store';
 
 export default function OutputNode({ id }: NodeProps) {
   const result = useExecutionStore((s) => s.results[id]);
+  const formatted = JSON.stringify(result, null, 2);
 
   return (
-    <div className="bg-white p-2 rounded shadow-md border w-48 text-xs">
-      <div className="text-[10px] break-all">{JSON.stringify(result)}</div>
+    <div className="bg-white p-2 rounded shadow-md border text-xs max-w-xs max-h-40 w-fit overflow-auto">
+      <pre className="text-[10px] whitespace-pre-wrap break-words">
+        {formatted}
+      </pre>
       <Handle type="target" position={Position.Top} />
     </div>
   );


### PR DESCRIPTION
## Summary
- prettify JSON output using `<pre>`
- allow OutputNode to grow up to a max size and scroll

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68548f4143bc832ead670054b6327f02