### PR TITLE
fix output node text wrapping

### DIFF
--- a/src/components/nodes/OutputNode.tsx
+++ b/src/components/nodes/OutputNode.tsx
@@ -6,8 +6,8 @@ export default function OutputNode({ id }: NodeProps) {
   const formatted = JSON.stringify(result, null, 2);
 
   return (
-    <div className="bg-white p-2 rounded shadow-md border text-xs w-sm max-w-md overflow-auto">
-      <pre className="text-[10px]">
+    <div className="bg-white p-2 rounded shadow-md border text-xs w-60 overflow-auto">
+      <pre className="text-[10px] whitespace-pre-wrap break-words">
         {formatted}
       </pre>
       <Handle type="target" position={Position.Top} />


### PR DESCRIPTION
## Summary
- ensure text wraps correctly in OutputNode

## Testing
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_685495e67e6c832ebba2b6fcdf2e8286