### PR TITLE
Improve JSON viewer in output node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@xyflow/react": "^12.7.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-json-view-lite": "^2.4.1",
         "zustand": "^4.4.7"
       },
       "devDependencies": {
@@ -2292,6 +2293,18 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-json-view-lite": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-2.4.1.tgz",
+      "integrity": "sha512-fwFYknRIBxjbFm0kBDrzgBy1xa5tDg2LyXXBepC5f1b+MY3BUClMCsvanMPn089JbV1Eg3nZcrp0VCuH43aXnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -8,19 +8,20 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@xyflow/react": "^12.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@xyflow/react": "^12.7.0",
+    "react-json-view-lite": "^2.4.1",
     "zustand": "^4.4.7"
   },
   "devDependencies": {
     "@types/react": "^18.2.12",
     "@types/react-dom": "^18.2.4",
     "@vitejs/plugin-react": "^4.1.0",
-    "typescript": "^5.2.2",
-    "vite": "^4.4.5",
-    "tailwindcss": "^3.3.3",
     "autoprefixer": "^10.4.12",
-    "postcss": "^8.4.26"
+    "postcss": "^8.4.26",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.5"
   }
 }

--- a/src/components/nodes/OutputNode.tsx
+++ b/src/components/nodes/OutputNode.tsx
@@ -1,15 +1,14 @@
 import { NodeProps, Handle, Position } from '@xyflow/react';
+import { JsonView, collapseAllNested, defaultStyles } from 'react-json-view-lite';
+import 'react-json-view-lite/dist/index.css';
 import { useExecutionStore } from '../../store';
 
 export default function OutputNode({ id }: NodeProps) {
   const result = useExecutionStore((s) => s.results[id]);
-  const formatted = JSON.stringify(result, null, 2);
 
   return (
-    <div className="bg-white p-2 rounded shadow-md border text-xs w-60 overflow-auto">
-      <pre className="text-[10px] whitespace-pre-wrap break-words">
-        {formatted}
-      </pre>
+    <div className="bg-white p-2 rounded shadow-md border text-xs w-60 max-h-60 overflow-auto">
+      <JsonView data={result} shouldExpandNode={collapseAllNested} style={defaultStyles} />
       <Handle type="target" position={Position.Top} />
     </div>
   );


### PR DESCRIPTION
## Summary
- add `react-json-view-lite` for collapsible JSON with syntax highlighting
- wrap output with scrollable container

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68549831456c832e82da1e86ba89461d